### PR TITLE
Added measurement or field filtering

### DIFF
--- a/Influxer/Program.cs
+++ b/Influxer/Program.cs
@@ -1,4 +1,5 @@
-﻿//Copyright -  Adarsha@AdysTech
+//Copyright -  Adarsha@AdysTech
+//https://github.com/AdysTech/Influxer/blob/master/Influxer/Program.cs
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -16,6 +17,19 @@ namespace AdysTech.Influxer
 {
     class Program
     {
+        enum Filters
+        {
+            None,
+            Measurement,
+            Field
+        }
+
+		enum FileFormats
+		{
+			Perfmon,
+			Generic
+		}
+		
         const string InfluxUrlSwitch = "-influx";
         const string InfluxDBSwitch = "-dbname";
         const string TagsSwitch = "-tags";
@@ -26,6 +40,7 @@ namespace AdysTech.Influxer
         const string InfluxPwdSwitch = "-pass";
         const string FileFormatSwitch = "-format";
         const string TableNameSwitch = "-table";
+        const string FilterSwitch = "-filter";
 
         private static string influxUrl;
         private static string influxDB;
@@ -35,9 +50,11 @@ namespace AdysTech.Influxer
         private static string inputFileName;
         private static char seperator = ',';
         private static string timeFormat = "MM/dd/yyyy HH:mm:ss.fff";
-        private static string fileFormat = "perfmon";
+        private static FileFormats fileFormat;
         private static string tableName;
         private static Regex pattern;
+        private static Filters filter;
+		private static Dictionary<string,List<string>> dbStructure;
 
         static int Main(string[] args)
         {
@@ -86,6 +103,8 @@ namespace AdysTech.Influxer
             if ( cmdArgs.ContainsKey (TagsSwitch) )
                 tags = cmdArgs[TagsSwitch].Replace (' ', '_');
 
+			if ( cmdArgs.ContainsKey (TableNameSwitch) )
+                tableName = cmdArgs[TableNameSwitch];
 
             if ( cmdArgs.ContainsKey (InputFileNameSwitch) )
             {
@@ -116,23 +135,35 @@ namespace AdysTech.Influxer
 
             if ( cmdArgs.ContainsKey (FileFormatSwitch) )
             {
-                fileFormat = cmdArgs[FileFormatSwitch].ToLower ();
-                if ( !new[] { "perfmon", "generic" }.Contains (fileFormat) )
+                if(!Enum.TryParse<FileFormats>(cmdArgs[FileFormatSwitch], true, out fileFormat) || !Enum.IsDefined(typeof(FileFormats), fileFormat))
                 {
-                    Console.WriteLine ("Not supported format{0}!!", fileFormat);
+                    Console.WriteLine ("Not supported format{0}!!", cmdArgs[FileFormatSwitch]);
                     return 1;
                 }
             }
+			{
+				fileFormat = FileFormats.Perfmon;
+			}
 
-            if ( cmdArgs.ContainsKey (TableNameSwitch) )
-                tableName = cmdArgs[TableNameSwitch];
+            if ( cmdArgs.ContainsKey (FilterSwitch) )
+			{
+				if(!Enum.TryParse<Filters>(cmdArgs[FilterSwitch], true, out filter) || !Enum.IsDefined(typeof(Filters), filter))
+				{
+					Console.WriteLine ("Not supported filter:{0}!!", cmdArgs[FilterSwitch]);
+                    return 1;
+				}
+			}
+			else
+			{
+				filter = Filters.None;
+			}
 
             #endregion
             try
             {
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
-                
+
                 HttpClientHandler handler = new HttpClientHandler ();
                 handler.UseDefaultCredentials = true;
                 handler.PreAuthenticate = true;
@@ -143,24 +174,30 @@ namespace AdysTech.Influxer
                 if ( !( String.IsNullOrWhiteSpace (influxDBUserName) && String.IsNullOrWhiteSpace (influxDBPassword) ) )
                     client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue ("Basic", Convert.ToBase64String (System.Text.ASCIIEncoding.ASCII.GetBytes (string.Format ("{0}:{1}", influxDBUserName, influxDBPassword))));
 
-                if ( !VerifyDatabase (client, influxDB).Result )
+                if ( !VerifyDatabaseAsync(client, influxDB).Result )
                 {
                     Console.WriteLine ("Unable to create DB {0}", influxDB);
                     return -1;
                 }
 
+
+				if(filter!=Filters.None)
+					dbStructure = GetInfluxDBStructureAsync(client,new Uri (influxUrl + "/query?"),influxDB).Result;
+
+
                 var result = false;
                 switch ( fileFormat )
                 {
-                    case "perfmon":
+                    case FileFormats.Perfmon:
                         result = ProcessPerfMonLog (inputFileName, client).Result;
                         break;
-                    case "generic":
+                    case FileFormats.Generic:
                         if ( String.IsNullOrWhiteSpace (tableName) )
                             throw new ArgumentException ("Generic format needs TableName input");
                         result = ProcessGenericFile (inputFileName, tableName, client).Result;
                         break;
                 }
+
                 stopwatch.Stop();
                 if ( result )
                 {
@@ -178,7 +215,7 @@ namespace AdysTech.Influxer
             return 0;
         }
 
-        private static async Task<bool> VerifyDatabase(HttpClient client, string DBName)
+        private static async Task<bool> VerifyDatabaseAsync(HttpClient client, string DBName)
         {
             var influxAddress = new Uri (influxUrl + "/query?");
 
@@ -190,6 +227,11 @@ namespace AdysTech.Influxer
                 return true;
             else
             {
+				if(filter!=Filters.None)
+				{	
+					Console.WriteLine("Measurement/Field filtering is not applicable for new database!!");
+					filter=Filters.None;
+				}
                 return await CreateInfluxDBAsync (client, DBName, influxAddress);
             }
         }
@@ -221,6 +263,62 @@ namespace AdysTech.Influxer
             return null;
         }
 
+		private static async Task<Dictionary<string,List<String>>> GetInfluxDBStructureAsync(HttpClient client, Uri InfluxPath, string dbName)
+        {
+			var dbStructure = new Dictionary<string,List<string>>();
+            try
+			{
+				var builder = new UriBuilder (InfluxPath);
+				//builder.UserName = influxDBUserName;
+				//builder.Password = influxDBPassword;
+				builder.Query = await new FormUrlEncodedContent (new[] { 
+					new KeyValuePair<string, string>("u",influxDBUserName) ,
+					new KeyValuePair<string, string>("p", influxDBPassword) ,
+					new KeyValuePair<string, string>("db", dbName) ,
+					new KeyValuePair<string, string>("q", "SHOW FIELD KEYS") 
+					}).ReadAsStringAsync ();
+				HttpResponseMessage response = await client.GetAsync (builder.Uri);
+
+				if ( response.StatusCode == HttpStatusCode.OK )
+				{
+					var content = await response.Content.ReadAsStringAsync ();
+					var values=Regex.Matches (content, "([a-zA-Z0-9_]+)").Cast<Match>().Select (match => match.Value).ToList();
+					string measurement;
+					//one pass loop through the entries in returned structure. Each new measurement starts with "name",measurement name, "columns","fieldKey","values",list of columns
+					//we will search for name, and once found grab measurement name, skip 3 lines, and grab column names
+					for(int i=0;i<values.Count;i++)
+					{
+						if(values[i]!="name")
+							continue;
+						if(values[i]=="name")
+						{
+							if(++i==values.Count) 
+								throw new InvalidDataException("Invalid data returned from InfluxDB");
+							//i is incremented
+							measurement=values[i];
+							dbStructure.Add(measurement,new List<string>());
+							for(int j=i+4;j<values.Count;j++)
+							{
+								if(values[j]=="name")
+								{
+									i=j-1;
+									break;
+								}
+								dbStructure[measurement].Add(values[j]);
+							}
+						}
+					}
+				}
+			}
+			catch ( HttpRequestException e )
+			{
+
+			}
+
+			return dbStructure;
+        }
+		
+		
         private static async Task<bool> CreateInfluxDBAsync(HttpClient client, string dbName, Uri InfluxPath)
         {
             try
@@ -231,7 +329,7 @@ namespace AdysTech.Influxer
                 builder.Query = await new FormUrlEncodedContent (new[] { 
                     new KeyValuePair<string, string>("u",influxDBUserName) ,
                     new KeyValuePair<string, string>("p", influxDBPassword) ,
-                    new KeyValuePair<string, string>("q", "CREATE DATABASE "+dbName) 
+                    new KeyValuePair<string, string>("q", "CREATE DATABASE "+ dbName) 
                     }).ReadAsStringAsync ();
                 HttpResponseMessage response = await client.GetAsync (builder.Uri);
 
@@ -265,7 +363,7 @@ namespace AdysTech.Influxer
                 else
                     return false;
             }
-            catch ( HttpRequestException e )
+            catch ( HttpRequestException ex )
             {
                 return false;
             }
@@ -288,53 +386,47 @@ namespace AdysTech.Influxer
                 var failedCount = 0;
                 StringBuilder content = new StringBuilder ();
 
-                //Stopwatch stopwatch = new Stopwatch();
-                //stopwatch.Start();
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
 
                 var influxAddress = new Uri (influxUrl + "/write?db=" + influxDB + "&precision=s");
 
-                List<PerfmonCounter> pecrfCounters = new List<PerfmonCounter> ();
-                IEnumerable<IGrouping<string, PerfmonCounter>> perfGourp = null;
-
-
-                var firstLine = File.ReadLines (InputFileName).FirstOrDefault ();
-                var columns = pattern.Split (firstLine.Replace ("\"", ""));
-
-                if ( !columns[0].Contains ("PDH-CSV") )
+                
+                var firstLine = File.ReadLines (InputFileName).FirstOrDefault ();                
+                
+				var firstCol = firstLine.Substring(0, firstLine.IndexOf(','));
+				if ( !firstCol.Contains ("PDH-CSV") )
                     throw new Exception ("Input file is not a Standard Perfmon csv file");
-                var x = Regex.Matches (columns[0], "([-0-9]+)");
+                var x = Regex.Matches (firstCol, "([-0-9]+)");
                 if ( x.Count > 0 )
-                    minOffset = int.Parse (x[3].ToString ());
-                //get the column headers
-               var column = 1;
-               var influxIdentifiers = new char[]{' ',';','_','(',')','%'};
-               var whiteSpace = new char[]{'_'};
-               pecrfCounters.AddRange (columns.Skip (1).Where (s => s.StartsWith ("\\")).Select (p => 
-                		p.Replace (influxIdentifiers, "_").Split ('\\')).Select (p => 
-                			new PerfmonCounter () 
-                			{ 
-                				ColumnIndex = column++, 
-                				Host = p[2].Trim(whiteSpace), 
-                				PerformanceObject = p[3].Trim(whiteSpace), 
-                				CounterName = p[4].Trim(whiteSpace) 
-                			}));
-                perfGourp = pecrfCounters.GroupBy (p => p.PerformanceObject);
+        			minOffset = int.Parse (x[3].ToString ());
+				
+				//get the column headers
+			   try
+			   {
+			   		List<PerfmonCounter> pecrfCounters = ParsePerfMonFileHeader(firstLine);
+			   }
+			   catch(Exception ex)
+			   {
+				   throw new InvalidDataException("Unable to parse file headers",ex);
+			   }
+				
+               IEnumerable<IGrouping<string, PerfmonCounter>> perfGourp = pecrfCounters.GroupBy (p => p.PerformanceObject);
 
                 //Parallel.ForEach (File.ReadLines (inputFileName).Skip (1), (string line) =>
                 foreach ( var line in File.ReadLines (InputFileName).Skip (1) )
                 {
                     try
                     {
-                        if ( await ProcessPerfmonLogLine (line, perfGourp, minOffset, pattern, client, influxAddress) )
-                        {
-                            lineCount++;
-                            Console.Write ("\r Processed {0}                          ", lineCount);
-                        }
-                        else
-                        {
-                            failedCount++; lineCount++;
-                            Console.Write ("\r Processed {0}, Failed - {1}                        ", lineCount, failedCount);
-                        }
+                        if (! await ProcessPerfmonLogLine (line, perfGourp, minOffset, pattern, client, influxAddress) )
+                            failedCount++; 
+
+						lineCount++;
+
+						if(failedCount>0)
+							Console.Write ("\r{0} Processed {1}, Failed - {2}                        ",stopwatch.Elapsed.ToString("hh:mm:ss"), lineCount, failedCount);
+						else
+							Console.Write ("\r{0} Processed {1}                          ",stopwatch.Elapsed.ToString("hh:mm:ss"), lineCount);	
                     }
                     catch ( Exception e )
                     {
@@ -345,7 +437,7 @@ namespace AdysTech.Influxer
                 }
 
 
-                //stopwatch.Stop();
+                stopwatch.Stop();
                 //Debug.WriteLine("Done Async Processing, Time elapsed: {0}", stopwatch.Elapsed);
 
                 lineCount = 0;
@@ -362,6 +454,26 @@ namespace AdysTech.Influxer
             }
             return true;
         }
+		
+		private static List<PerfmonCounter> ParsePerfMonFileHeader(string headerLine)
+        {
+			List<PerfmonCounter> pecrfCounters = new List<PerfmonCounter> ();
+			var columns = pattern.Split (firstLine);			
+			var column = 1;
+			var influxIdentifiers = new char[]{' ',';','_','(',')','%','#','.','/','[',']','{','}','"'};
+			var whiteSpace = new char[]{'_'};
+			pecrfCounters.AddRange (columns.Skip (1).Where (s => s.StartsWith ("\"\\")).Select (p => 
+					p.Replace (influxIdentifiers, "_").Split ('\\')).Select (p => 
+						new PerfmonCounter () 
+						{ 
+							ColumnIndex = column++, 
+							Host = p[2].Trim(whiteSpace), 
+							PerformanceObject = p[3].Trim(whiteSpace), 
+							CounterName = p[4].Trim(whiteSpace) 
+						}));
+			return pecrfCounters;
+        }
+
 
         private static async Task<bool> ProcessPerfmonLogLine(string line, IEnumerable<IGrouping<string, PerfmonCounter>> perfGourp, int minOffset, Regex pattern, HttpClient client, Uri InfluxPath)
         {
@@ -385,21 +497,30 @@ namespace AdysTech.Influxer
                     foreach ( var hostGrp in group.GroupBy (p => p.Host) )
                     {
                         lineStartIndex = content.Length;
-                        content.AppendFormat ("{0},Host={1}", group.Key, hostGrp.Key);
+						if(filter == Filters.None || dbStructure.ContainsKey(group.Key))
+                        	content.AppendFormat ("{0},Host={1}", group.Key, hostGrp.Key);
+						else
+							continue;
+
                         if ( tags != null )
                             content.AppendFormat (",{0} ", tags);
                         else
                             content.Append (" ");
 
                         var useCounter = false;
+
                         foreach ( var counter in hostGrp )
                         {
                             if ( !String.IsNullOrWhiteSpace (columns[counter.ColumnIndex]) && Double.TryParse (columns[counter.ColumnIndex], out value) )
                             {
-                                content.AppendFormat ("{0}={1:0.00},", counter.CounterName, value);
-                                useCounter = true;
+								if(filter != Filters.Field || dbStructure[group.Key].Any(s=>s==counter.CounterName))
+								{
+									content.AppendFormat ("{0}={1:0.00},", counter.CounterName, value);
+                                	useCounter = true;
+								}
                             }
                         }
+
                         if ( useCounter )
                             content.AppendFormat (" {0}\n", epoch);
                         else
@@ -452,16 +573,16 @@ namespace AdysTech.Influxer
                 {
                     try
                     {
-                        if ( await ProcessGenericLine (line, columnHeaders, pattern, client, influxAddress) )
-                        {
-                            lineCount++;
-                            Console.Write ("\r Processed {0}                          ", lineCount);
-                        }
-                        else
-                        {
-                            failedCount++; lineCount++;
-                            Console.Write ("\r Processed {0}, Failed - {1}                        ", lineCount, failedCount);
-                        }
+                        if (! await ProcessGenericLine (line, columnHeaders, pattern, client, influxAddress) )
+                            failedCount++; 
+
+						lineCount++;
+
+						if(failedCount>0)
+							Console.Write ("\r Processed {0}, Failed - {1}                        ", lineCount, failedCount);
+						else
+							Console.Write ("\r Processed {0}                          ", lineCount);	
+
                     }
                     catch ( Exception e )
                     {


### PR DESCRIPTION
Sometimes files can have huge number of columns (specially PerfMon run on a server with high number of processor cores, with all counters enabled can have more than 800 columns). For the data analysis we may not need all that data. Hense its now possible to filter only specific measurement which is already present in db or few fields in those measurements (e.g. Only %User Time counter from Processor(Total)). 
Also updated header parsing, moved to a new method, added a function to get InfluxDB hierarchical structure, few more bug fixes.
