### PR TITLE
Handle partial writes to InfluxDB

### DIFF
--- a/Influxer/DebugHelper.cs
+++ b/Influxer/DebugHelper.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdysTech.Influxer
+{
+    class DebugHelper : TextWriter
+    {
+        public override Encoding Encoding
+        {
+            get { return Encoding.UTF8; }
+        }
+
+        public override void Write(char value)
+        {
+            Debug.Write (value);
+        }
+
+        public override void Write(string value)
+        {
+            Debug.Write (value);
+        }
+
+        public override void WriteLine(string value)
+        {
+            Debug.WriteLine (value);
+        }
+
+        public override void Write(string format, params object[] arg)
+        {
+            Debug.WriteLine (format, arg);
+        }
+
+        public override void Write(string format, object arg0, object arg1)
+        { Debug.WriteLine (format, new object[] { arg0, arg1 }); }
+
+        public override void Write(string format, object arg0, object arg1, object arg2)
+        {
+            Debug.WriteLine (format, new object[] { arg0, arg1, arg2 });
+        }
+
+
+        public override void WriteLine(string format, object arg0)
+        {
+            Debug.Write (format, arg0.ToString ());
+        }
+
+        public override void WriteLine(string format, object arg0, object arg1)
+        {
+            Debug.WriteLine (format, new object[] { arg0, arg1 });
+        }
+
+        public override void WriteLine(string format, object arg0, object arg1, object arg2)
+        {
+            Debug.WriteLine (format, new object[] { arg0, arg1, arg2 });
+        }
+    }
+}

--- a/Influxer/GenericFile.cs
+++ b/Influxer/GenericFile.cs
@@ -35,10 +35,12 @@ namespace AdysTech.Influxer
 
         public async Task<ExitCode> ProcessGenericFile(string InputFileName, string tableName, InfluxDBClient client)
         {
+            var linesProcessed = 0;
+            var failedLines = 0;
+            int failedReqCount = 0;
+
             try
             {
-                var lineCount = 0;
-                var failedCount = 0;
                 Stopwatch stopwatch = new Stopwatch ();
                 stopwatch.Start ();
 
@@ -61,7 +63,7 @@ namespace AdysTech.Influxer
 
                 var failureReasons = new Dictionary<Type, FailureTracker> ();
 
-                var points = new List<IInfluxDatapoint> ();
+                List<IInfluxDatapoint> points = new List<IInfluxDatapoint> (), retryQueue = new List<IInfluxDatapoint> ();
 
                 //Parallel.ForEach (File.ReadLines (inputFileName).Skip (1), (string line) =>
                 foreach ( var line in File.ReadLines (InputFileName).Skip (settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows) )
@@ -70,71 +72,98 @@ namespace AdysTech.Influxer
                     {
                         var point = ProcessGenericLine (line, columnHeaders);
                         if ( point == null )
-                            failedCount++;
+                            failedLines++;
                         else
                             points.Add (point);
 
                         if ( points.Count >= settings.InfluxDB.PointsInSingleBatch )
                         {
-                            var result = await client.PostPointsAsync (settings.InfluxDB.DatabaseName, points);
+                            bool result = false;
+                            try
+                            {
+                                result = await client.PostPointsAsync (settings.InfluxDB.DatabaseName, points);
+                            }
+                            catch ( ServiceUnavailableException )
+                            {
+                                result = false;
+                            }
+
                             if ( result )
-                                points.Clear ();
+                            {
+                                failedReqCount = 0;
+                            }
                             else
                             {
-                                //keep only failed points in the list
-                                points.RemoveAll (p => p.Saved == true);
+                                //add failed to retry queue
+                                retryQueue.AddRange (points.Where (p => p.Saved != true));
 
-                                //points that fail on first try will remain and sent again on second request to InfluxDBClient
-                                Console.Error.WriteLine ("{0} points failed to write to Influx", points.Count);
-
-                                //avoid retrying forever
-                                if ( points.Count >= settings.InfluxDB.PointsInSingleBatch * 3 )
+                                //avoid failing on too many points
+                                if ( ++failedReqCount > 3 )
                                     break;
                             }
+                            //a point will be either posted to Influx or in retry queue
+                            points.Clear ();
                         }
                     }
                     catch ( Exception e )
                     {
-                        failedCount++;
+                        failedLines++;
                         var type = e.GetType ();
                         if ( !failureReasons.ContainsKey (type) )
                             failureReasons.Add (type, new FailureTracker () { ExceptionType = type, Message = e.Message });
-                        failureReasons[type].LineNumbers.Add (lineCount + settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows + 1);
+                        failureReasons[type].LineNumbers.Add (linesProcessed + settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows + 1);
                     }
 
-                    lineCount++;
+                    linesProcessed++;
 
-                    if ( failedCount > 0 )
-                        Console.Write ("\r{0} Processed {1}, Failed - {2}                        ", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), lineCount, failedCount);
+                    if ( failedLines > 0 || retryQueue.Count > 0 )
+                        Console.Write ("\r{0} Processed {1}, Failed {2}, Queued {3}                        ", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), linesProcessed, failedLines, retryQueue.Count);
                     else
-                        Console.Write ("\r{0} Processed {1}                          ", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), lineCount);
+                        Console.Write ("\r{0} Processed {1}                          ", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), linesProcessed);
 
                 }
+
+                //if we reached here due to repeated failures
+                if ( retryQueue.Count >= settings.InfluxDB.PointsInSingleBatch * 3 || failedReqCount > 3 )
+                    throw new InvalidOperationException ("InfluxDB is not able to accept points!! Please check InfluxDB logs for error details!");
+
+
                 //finally few points may be left out which were not processed (say 10 points left, but we check for 100 points in a batch)
-                if ( points != null )
+                if ( points != null && points.Count > 0 )
                 {
+
                     if ( await client.PostPointsAsync (settings.InfluxDB.DatabaseName, points) )
                         points.Clear ();
                     else
                     {
-                        //any previously failed points will remain here, and we need to indicate this in return status
-                        points.RemoveAll (p => p.Saved == true);
+                        failedReqCount++;
+                        //add failed to retry queue
+                        retryQueue.AddRange (points.Where (p => p.Saved != true));
+                    }
+                }
 
-                        Console.Error.WriteLine ("{0} points failed to write to Influx", points.Count);
-                        failedCount += points.Count;
-                        if ( points.Count >= settings.InfluxDB.PointsInSingleBatch * 3 )
+                //retry all previously failed points
+                if ( retryQueue.Count > 0 )
+                {
+                    Console.WriteLine ("\n {0} Retrying {1} failed points", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), retryQueue.Count);
+                    if ( await client.PostPointsAsync (settings.InfluxDB.DatabaseName, retryQueue) )
+                        retryQueue.Clear ();
+                    else
+                    {
+                        failedLines += retryQueue.Count;
+                        if ( retryQueue.Count >= settings.InfluxDB.PointsInSingleBatch * 3 || ++failedReqCount > 4 )
                             throw new InvalidOperationException ("InfluxDB is not able to accept points!! Please check InfluxDB logs for error details!");
                     }
                 }
 
                 stopwatch.Stop ();
-                if ( failedCount > 0 )
+                if ( failedLines > 0 )
                 {
-                    Console.WriteLine ("\n Done!! Processed {0}, failed to insert {1}", lineCount, failedCount);
-                    Console.Error.WriteLine ("Process Started {0}, Input {1}, Processed{2}, Failed:{3}", ( DateTime.Now - stopwatch.Elapsed ), InputFileName, lineCount, failedCount);
+                    Console.WriteLine ("\n Done!! Processed {0}, failed to insert {1}", linesProcessed, failedLines);
+                    Console.Error.WriteLine ("Process Started {0}, Input {1}, Processed{2}, Failed:{3}", ( DateTime.Now - stopwatch.Elapsed ), InputFileName, linesProcessed, failedLines);
                     foreach ( var f in failureReasons.Values )
                         Console.Error.WriteLine ("{0} lines ({1}) failed due to {2} ({3})", f.Count, String.Join (",", f.LineNumbers), f.ExceptionType, f.Message);
-                    if ( failedCount == lineCount )
+                    if ( failedLines == linesProcessed )
                         return ExitCode.UnableToProcess;
                     else
                         return ExitCode.ProcessedWithErrors;

--- a/Influxer/GenericFile.cs
+++ b/Influxer/GenericFile.cs
@@ -79,8 +79,18 @@ namespace AdysTech.Influxer
                             var result = await client.PostPointsAsync (settings.InfluxDB.DatabaseName, points);
                             if ( result )
                                 points.Clear ();
-                            else if ( points.Count >= settings.InfluxDB.PointsInSingleBatch * 2 )
-                                throw new InvalidOperationException ("InfluxDB is not able to accept points!! Please check InfluxDB logs for error details!");
+                            else
+                            {
+                                //keep only failed points in the list
+                                points.RemoveAll (p => p.Saved == true);
+
+                                //points that fail on first try will remain and sent again on second request to InfluxDBClient
+                                Console.Error.WriteLine ("{0} points failed to write to Influx", points.Count);
+
+                                //avoid retrying forever
+                                if ( points.Count >= settings.InfluxDB.PointsInSingleBatch * 3 )
+                                    break;
+                            }
                         }
                     }
                     catch ( Exception e )
@@ -100,13 +110,28 @@ namespace AdysTech.Influxer
                         Console.Write ("\r{0} Processed {1}                          ", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), lineCount);
 
                 }
-                if ( await client.PostPointsAsync (settings.InfluxDB.DatabaseName, points) )
-                    points.Clear ();
+                //finally few points may be left out which were not processed (say 10 points left, but we check for 100 points in a batch)
+                if ( points != null )
+                {
+                    if ( await client.PostPointsAsync (settings.InfluxDB.DatabaseName, points) )
+                        points.Clear ();
+                    else
+                    {
+                        //any previously failed points will remain here, and we need to indicate this in return status
+                        points.RemoveAll (p => p.Saved == true);
+
+                        Console.Error.WriteLine ("{0} points failed to write to Influx", points.Count);
+                        failedCount += points.Count;
+                        if ( points.Count >= settings.InfluxDB.PointsInSingleBatch * 3 )
+                            throw new InvalidOperationException ("InfluxDB is not able to accept points!! Please check InfluxDB logs for error details!");
+                    }
+                }
 
                 stopwatch.Stop ();
                 if ( failedCount > 0 )
                 {
                     Console.WriteLine ("\n Done!! Processed {0}, failed to insert {1}", lineCount, failedCount);
+                    Console.Error.WriteLine ("Process Started {0}, Input {1}, Processed{2}, Failed:{3}", ( DateTime.Now - stopwatch.Elapsed ), InputFileName, lineCount, failedCount);
                     foreach ( var f in failureReasons.Values )
                         Console.Error.WriteLine ("{0} lines ({1}) failed due to {2} ({3})", f.Count, String.Join (",", f.LineNumbers), f.ExceptionType, f.Message);
                     if ( failedCount == lineCount )
@@ -118,6 +143,7 @@ namespace AdysTech.Influxer
             }
             catch ( Exception e )
             {
+                Console.Error.WriteLine ("Failed to process {0}", InputFileName);
                 Console.Error.WriteLine ("\r\nError!! {0}:{1} - {2}", e.GetType ().Name, e.Message, e.StackTrace);
                 return ExitCode.UnknownError;
             }

--- a/Influxer/Influxer.csproj
+++ b/Influxer/Influxer.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Config\IOverridableConfig.cs" />
     <Compile Include="Config\OverridableConfigElement.cs" />
     <Compile Include="Config\PerfmonFileConfig.cs" />
+    <Compile Include="DebugHelper.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="FailureTracker.cs" />
     <Compile Include="GenericColumn.cs" />

--- a/Influxer/Program.cs
+++ b/Influxer/Program.cs
@@ -38,6 +38,12 @@ namespace AdysTech.Influxer
         static int Main(string[] args)
         {
 
+            if ( Debugger.IsAttached )
+            {
+                Console.SetError (new DebugHelper ());
+                Console.SetOut (new DebugHelper ());
+            }
+
             #region Command Line argument processing
             if ( args.Length == 0 )
             {

--- a/Influxer/Properties/AssemblyInfo.cs
+++ b/Influxer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion ("0.3.1.0")]
-[assembly: AssemblyFileVersion ("0.3.1.0")]
+[assembly: AssemblyVersion ("0.3.2.0")]
+[assembly: AssemblyFileVersion ("0.3.2.0")]

--- a/Influxer/Properties/AssemblyInfo.cs
+++ b/Influxer/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("Adys Tech")]
 [assembly: AssemblyProduct ("Influxer")]
-[assembly: AssemblyCopyright ("AdysTech © 2015")]
+[assembly: AssemblyCopyright ("AdysTech © 2016")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion ("0.3.0.0")]
-[assembly: AssemblyFileVersion ("0.3.0.0")]
+[assembly: AssemblyVersion ("0.3.1.0")]
+[assembly: AssemblyFileVersion ("0.3.1.0")]


### PR DESCRIPTION
Certain cases InfluxDB engine may throw 500 errors, and these points were not properly handled before. Now they are added to a retry queue, and tried at the end again. This also allows handling for InfluxDB crashes while Influxer is still running. If InfluxDB comes back before 4th attempt, the restart of db engine will be transparent.

Also added is a debug helper which allows to see all Console.Write statements in Visual studio output window. 
