### PR TITLE
Configuration option to define column layout of a generic file

### DIFF
--- a/Influxer/Config/ColumnConfig.cs
+++ b/Influxer/Config/ColumnConfig.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdysTech.Influxer.Config
+{
+    public enum ColumnDataType : int
+    {
+        Unknown = 0,
+        Timestamp,
+        Tag,
+        Field
+    }
+
+    public class ColumnConfig : ConfigurationElement
+    {
+
+
+        [ConfigurationProperty("NameInFile")]
+        public string NameInFile
+        {
+            get { return (string)this["NameInFile"]; }
+            set { this["NameInFile"] = value; }
+        }
+
+        [ConfigurationProperty("InfluxName", IsRequired = true)]
+        public string InfluxName
+        {
+            get { return (string)this["InfluxName"]; }
+            set { this["InfluxName"] = value; }
+        }
+
+        [ConfigurationProperty("Skip", DefaultValue = false)]
+        public bool Skip
+        {
+            get { return (bool)this["Skip"]; }
+            set { this["Skip"] = value; }
+        }
+
+        [ConfigurationProperty("DataType")]
+        public ColumnDataType DataType
+        {
+            get { return (ColumnDataType)this["DataType"]; }
+            set { this["DataType"] = value; }
+        }
+    }
+}

--- a/Influxer/Config/ColumnLayoutConfig.cs
+++ b/Influxer/Config/ColumnLayoutConfig.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdysTech.Influxer.Config
+{
+    [ConfigurationCollection(typeof(ColumnConfig),
+    CollectionType = ConfigurationElementCollectionType.BasicMap)]
+    public class ColumnLayoutConfig : ConfigurationElementCollection
+    {
+
+        public ColumnConfig this[int Index]
+        {
+            get
+            {
+                return base.BaseGet(Index) as ColumnConfig;
+            }
+            set
+            {
+
+                if (base.Count > Index && base.BaseGet(Index) != null)
+                {
+                    base.BaseRemoveAt(Index);
+                }
+                this.BaseAdd(Index, value);
+            }
+        }
+
+        new public ColumnConfig this[string Key]
+        {
+            get
+            {
+                return base.BaseGet(Key) as ColumnConfig;
+            }
+        }
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new ColumnConfig();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return (element as ColumnConfig).InfluxName;
+        }
+    }
+}

--- a/Influxer/Config/GenericFileConfig.cs
+++ b/Influxer/Config/GenericFileConfig.cs
@@ -50,5 +50,34 @@ namespace AdysTech.Influxer.Config
             set { this["SkipRows"] = value; }
         }
 
+        [CommandLineArgAttribute("-ignore", Usage = "-ignore <char>", Description = "Lines starting with <char> are considered as comments, and ignored")]
+        [ConfigurationProperty("CommentMarker")]
+        public string CommentMarker
+        {
+            get { return (string)this["CommentMarker"]; }
+            set { this["CommentMarker"] = value; }
+        }
+
+        [ConfigurationProperty("TimeColumn", DefaultValue = 1)]
+        public int TimeColumn
+        {
+            get { return (int)this["TimeColumn"]; }
+            set { this["TimeColumn"] = value; }
+        }
+
+        [CommandLineArgAttribute("-noheader", Usage = "-noheader true", Description = "Input file does not have column headers, configuration file should provide a column header mapping")]
+        [ConfigurationProperty("HeaderMissing")]
+        public bool HeaderMissing
+        {
+            get { return (bool)this["HeaderMissing"]; }
+            set { this["HeaderMissing"] = value; }
+        }
+
+        [ConfigurationProperty("ColumnLayout")]
+        public ColumnLayoutConfig ColumnLayout
+        {
+            get { return (ColumnLayoutConfig)this["ColumnLayout"]; }
+            set { this["ColumnLayout"] = value; }
+        }
     }
 }

--- a/Influxer/Config/InfluxerConfigSection.cs
+++ b/Influxer/Config/InfluxerConfigSection.cs
@@ -27,37 +27,37 @@ namespace AdysTech.Influxer.Config
 
     public class InfluxerConfigSection : ConfigurationSection, IOverridableConfig
     {
-        [CommandLineArgAttribute ("-input", Usage = "-input <file name>", Description = "Input file name")]
-        [ConfigurationProperty ("InputFileName")]
+        [CommandLineArgAttribute("-input", Usage = "-input <file name>", Description = "Input file name")]
+        [ConfigurationProperty("InputFileName")]
         public string InputFileName
         {
-            get { return (string) this["InputFileName"]; }
+            get { return (string)this["InputFileName"]; }
             set { this["InputFileName"] = value; }
         }
 
-        [CommandLineArgAttribute ("-format", Usage = "-format <format>", Description = "Input file format. Supported: Perfmon, Generic", DefaultValue = "Perfmon")]
-        [ConfigurationProperty ("FileFormat", DefaultValue = FileFormats.Perfmon)]
+        [CommandLineArgAttribute("-format", Usage = "-format <format>", Description = "Input file format. Supported: Perfmon, Generic", DefaultValue = "Perfmon")]
+        [ConfigurationProperty("FileFormat", DefaultValue = FileFormats.Perfmon)]
         public FileFormats FileFormat
         {
-            get { return (FileFormats) this["FileFormat"]; }
+            get { return (FileFormats)this["FileFormat"]; }
             set { this["FileFormat"] = value; }
         }
 
-        [ConfigurationProperty ("InfluxDBConfig")]
+        [ConfigurationProperty("InfluxDBConfig")]
         public InfluxDBConfig InfluxDB
         {
             get { return this["InfluxDBConfig"] as InfluxDBConfig; }
             set { this["InfluxDBConfig"] = value; }
         }
 
-        [ConfigurationProperty ("PerfmonFileConfig")]
+        [ConfigurationProperty("PerfmonFileConfig")]
         public PerfmonFileConfig PerfmonFile
         {
             get { return this["PerfmonFileConfig"] as PerfmonFileConfig; }
             set { this["PerfmonFileConfig"] = value; }
         }
 
-        [ConfigurationProperty ("GenericFileConfig")]
+        [ConfigurationProperty("GenericFileConfig")]
         public GenericFileConfig GenericFile
         {
             get { return this["GenericFileConfig"] as GenericFileConfig; }
@@ -68,77 +68,77 @@ namespace AdysTech.Influxer.Config
 
         public bool ProcessCommandLineArguments(Dictionary<string, string> CommandLine)
         {
-            if ( CommandLine == null || CommandLine.Count == 0 ) return true;
+            if (CommandLine == null || CommandLine.Count == 0) return true;
 
             bool found = false;
-            foreach ( var prop in this.GetType ().GetProperties () )
+            foreach (var prop in this.GetType().GetProperties())
             {
-                if ( CommandLine.Count == 0 )
+                if (CommandLine.Count == 0)
                     break;
 
-                var cmdAttribute = prop.GetCustomAttributes (typeof (CommandLineArgAttribute), true).FirstOrDefault () as CommandLineArgAttribute;
-                if ( cmdAttribute != null )
+                var cmdAttribute = prop.GetCustomAttributes(typeof(CommandLineArgAttribute), true).FirstOrDefault() as CommandLineArgAttribute;
+                if (cmdAttribute != null)
                 {
-                    if ( CommandLine.ContainsKey (cmdAttribute.Argument) )
+                    if (CommandLine.ContainsKey(cmdAttribute.Argument))
                     {
                         found = true;
                         try
                         {
-                            this[prop.Name] = this.Properties[prop.Name].Converter.ConvertFromString (CommandLine[cmdAttribute.Argument]);
+                            this[prop.Name] = this.Properties[prop.Name].Converter.ConvertFromString(CommandLine[cmdAttribute.Argument]);
                         }
-                        catch ( Exception e )
+                        catch (Exception e)
                         {
-                            throw new ArgumentException ("Invalid Argument " + cmdAttribute.Argument, e);
+                            throw new ArgumentException("Invalid Argument " + cmdAttribute.Argument, e);
                         }
-                        CommandLine.Remove (cmdAttribute.Argument);
+                        CommandLine.Remove(cmdAttribute.Argument);
                     }
                 }
             }
 
-            if ( CommandLine.Count == 0 )
+            if (CommandLine.Count == 0)
                 return found;
             bool ret;
-            ret = InfluxDB.ProcessCommandLineArguments (CommandLine);
-            if ( CommandLine.Count == 0 )
+            ret = InfluxDB.ProcessCommandLineArguments(CommandLine);
+            if (CommandLine.Count == 0)
                 return !found ? ret : found;
-            
+
             found = !found ? ret : found;
 
-            if ( FileFormat == FileFormats.Perfmon )
-                ret = PerfmonFile.ProcessCommandLineArguments (CommandLine);
+            if (FileFormat == FileFormats.Perfmon)
+                ret = PerfmonFile.ProcessCommandLineArguments(CommandLine);
             else
-                ret = GenericFile.ProcessCommandLineArguments (CommandLine);
+                ret = GenericFile.ProcessCommandLineArguments(CommandLine);
 
-            return !found ? ret : found; 
+            return !found ? ret : found;
         }
 
         public string PrintHelpText()
         {
-            StringBuilder help = new StringBuilder ();
-            help.AppendLine ("Required flags");
-            foreach ( var prop in this.GetType ().GetProperties () )
+            StringBuilder help = new StringBuilder();
+            help.AppendLine("Required flags");
+            foreach (var prop in this.GetType().GetProperties())
             {
-                var cmdAttribute = prop.GetCustomAttributes (typeof (CommandLineArgAttribute), true).FirstOrDefault () as CommandLineArgAttribute;
-                if ( cmdAttribute != null )
+                var cmdAttribute = prop.GetCustomAttributes(typeof(CommandLineArgAttribute), true).FirstOrDefault() as CommandLineArgAttribute;
+                if (cmdAttribute != null)
                 {
-                    help.AppendFormat ("{0,-40}\t\t{1,-100}", cmdAttribute.Usage, cmdAttribute.Description);
-                    if ( !String.IsNullOrWhiteSpace (cmdAttribute.DefaultValue) )
-                        help.AppendFormat ("\t Default:{0,-40}\n", cmdAttribute.DefaultValue);
+                    help.AppendFormat("{0,-40}\t\t{1,-100}", cmdAttribute.Usage, cmdAttribute.Description);
+                    if (!String.IsNullOrWhiteSpace(cmdAttribute.DefaultValue))
+                        help.AppendFormat("\t Default:{0,-40}\n", cmdAttribute.DefaultValue);
                     else
-                        help.Append ("\n");
+                        help.Append("\n");
                 }
             }
-            help.AppendLine (new String ('-', 180));
-            help.AppendLine ("InfluxDB related flags");
-            help.Append (InfluxDB.PrintHelpText ());
-            help.AppendLine (new String ('-', 180));
-            help.AppendLine ("Perfmon file format related flags");
-            help.Append (PerfmonFile.PrintHelpText ());
-            help.AppendLine (new String ('-', 180));
-            help.AppendLine ("Generic delimited file format related flags");
-            help.Append (GenericFile.PrintHelpText ());
+            help.AppendLine(new String('-', 180));
+            help.AppendLine("InfluxDB related flags");
+            help.Append(InfluxDB.PrintHelpText());
+            help.AppendLine(new String('-', 180));
+            help.AppendLine("Perfmon file format related flags");
+            help.Append(PerfmonFile.PrintHelpText());
+            help.AppendLine(new String('-', 180));
+            help.AppendLine("Generic delimited file format related flags");
+            help.Append(GenericFile.PrintHelpText());
 
-            return help.ToString ();
+            return help.ToString();
         }
 
         #endregion
@@ -151,8 +151,8 @@ namespace AdysTech.Influxer.Config
         /// <returns></returns>
         public static InfluxerConfigSection GetCurrentOrDefault()
         {
-            if ( _instance == null )
-                return LoadDefault ();
+            if (_instance == null)
+                return LoadDefault();
             else
                 return _instance;
         }
@@ -163,7 +163,7 @@ namespace AdysTech.Influxer.Config
         /// <returns>cref:InfluxerConfigSection</returns>
         public static InfluxerConfigSection LoadDefault()
         {
-            _instance = new InfluxerConfigSection ();
+            _instance = new InfluxerConfigSection();
             return _instance;
         }
 
@@ -175,7 +175,7 @@ namespace AdysTech.Influxer.Config
         /// <returns>InfluxerConfigSection created based on entries in config file</returns>
         public static InfluxerConfigSection Load(string path)
         {
-            if ( _instance == null )
+            if (_instance == null)
             {
                 //if ( path.EndsWith (".config",
                 //        StringComparison.InvariantCultureIgnoreCase) )
@@ -183,17 +183,17 @@ namespace AdysTech.Influxer.Config
                 //Configuration config =
                 //        ConfigurationManager.OpenExeConfiguration (path);
 
-                ExeConfigurationFileMap configMap = new ExeConfigurationFileMap ();
+                ExeConfigurationFileMap configMap = new ExeConfigurationFileMap();
                 configMap.ExeConfigFilename = path;
-                Configuration config = ConfigurationManager.OpenMappedExeConfiguration (configMap, ConfigurationUserLevel.None);
+                Configuration config = ConfigurationManager.OpenMappedExeConfiguration(configMap, ConfigurationUserLevel.None);
 
-                if ( config.Sections["InfluxerConfiguration"] != null )
+                if (config.Sections["InfluxerConfiguration"] != null)
                 {
-                    _instance = (InfluxerConfigSection) config.Sections["InfluxerConfiguration"];
+                    _instance = (InfluxerConfigSection)config.Sections["InfluxerConfiguration"];
                 }
                 else
                 {
-                    throw new InvalidOperationException ("InfluxerConfiguration section was not found!!, Use Config switch to get a config file with default values");
+                    throw new InvalidOperationException("InfluxerConfiguration section was not found!!, Use Config switch to get a config file with default values");
                 }
             }
             return _instance;
@@ -207,24 +207,44 @@ namespace AdysTech.Influxer.Config
         /// <returns>true: if successful, false otherwise</returns>
         public static bool Export(Stream outStream, bool defaultValues = false)
         {
-            var tmpFile = System.IO.Path.GetTempFileName ();
+            var tmpFile = System.IO.Path.GetTempFileName();
             try
             {
-                var config = ConfigurationManager.OpenExeConfiguration (ConfigurationUserLevel.None);
-                config.Sections.Add ("InfluxerConfiguration", defaultValues ? new InfluxerConfigSection () : _instance);
-                config.Sections["InfluxerConfiguration"].SectionInformation.ForceSave = true;
-                config.SaveAs (tmpFile, ConfigurationSaveMode.Full);
-                config = null;
-                using ( var content = File.OpenRead (tmpFile) )
+                var section = defaultValues ? new InfluxerConfigSection() : _instance;
+                Configuration config;
+                if (section.CurrentConfiguration == null)
                 {
-                    content.CopyTo (outStream);
-                    outStream.Flush ();
-                    content.Close ();
+                    config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                    config.Sections.Add("InfluxerConfiguration", section);
+                }
+                else
+                {
+                    config = section.CurrentConfiguration;
+                }
+
+                #region Add any sample values, but not added by default
+                if (defaultValues)
+                {
+                    if (section.GenericFile.ColumnLayout.Count == 0)
+                    {
+                        section.GenericFile.ColumnLayout[0] = new ColumnConfig() { NameInFile = "SampleColumn123, if this is missing column position is used", InfluxName = "Tag_ServerName", Skip = false, DataType = ColumnDataType.Tag };
+                    }
+                }
+                #endregion
+
+                config.Sections["InfluxerConfiguration"].SectionInformation.ForceSave = true;
+                config.SaveAs(tmpFile, ConfigurationSaveMode.Full);
+                config = null;
+                using (var content = File.OpenRead(tmpFile))
+                {
+                    content.CopyTo(outStream);
+                    outStream.Flush();
+                    content.Close();
                 }
             }
             finally
             {
-                File.Delete (tmpFile);
+                File.Delete(tmpFile);
             }
             return true;
         }

--- a/Influxer/GenericColumn.cs
+++ b/Influxer/GenericColumn.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AdysTech.Influxer.Config;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,13 +9,7 @@ namespace AdysTech.Influxer
 {
     class GenericColumn
     {
-        public enum ColumnDataType : int
-        {
-            Unknown = 0,
-            Tag,
-            Field
-        }
-
+     
         public int ColumnIndex { get; set; }
         public string ColumnHeader { get; set; }
         public ColumnDataType Type { get; set; }

--- a/Influxer/GenericFile.cs
+++ b/Influxer/GenericFile.cs
@@ -41,7 +41,9 @@ namespace AdysTech.Influxer
 
             try
             {
-
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+                List<GenericColumn> columnHeaders = new List<GenericColumn>();
                 if (settings.GenericFile.HeaderMissing && settings.GenericFile.ColumnLayout.Count == 0)
                 {
                     Console.WriteLine("Header missing, but no columns defined in configuration. Cannot proceed!!");
@@ -49,29 +51,26 @@ namespace AdysTech.Influxer
                     return ExitCode.InvalidArgument;
                 }
 
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
-
-
-                List<GenericColumn> columnHeaders = new List<GenericColumn>();
-
-                if (!settings.GenericFile.HeaderMissing)
+                else if (!settings.GenericFile.HeaderMissing)
                 {
                     var firstLine = File.ReadLines(InputFileName).Skip(settings.GenericFile.HeaderRow - 1).FirstOrDefault();
                     var columns = ParseGenericColumns(firstLine);
-                    foreach (var c in columns)
+                    if (settings.GenericFile.ColumnLayout.Count > 0)
                     {
-                        if (!String.IsNullOrWhiteSpace(settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile) && settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile != c.ColumnHeader)
+                        foreach (var c in columns)
                         {
-                            Console.WriteLine("Column Mismatch: Column[%0] defined in configuration %1, found %2. Cannot proceed!!", c.ColumnIndex, settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile, c.ColumnHeader);
-                            Console.Error.WriteLine("Column Mismatch: Column[%0] defined in configuration %1, found %2. Cannot proceed!!", c.ColumnIndex, settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile, c.ColumnHeader);
-                            return ExitCode.InvalidArgument;
-                        }
+                            if (!String.IsNullOrWhiteSpace(settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile) && settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile != c.ColumnHeader)
+                            {
+                                Console.WriteLine("Column Mismatch: Column[%0] defined in configuration %1, found %2. Cannot proceed!!", c.ColumnIndex, settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile, c.ColumnHeader);
+                                Console.Error.WriteLine("Column Mismatch: Column[%0] defined in configuration %1, found %2. Cannot proceed!!", c.ColumnIndex, settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile, c.ColumnHeader);
+                                return ExitCode.InvalidArgument;
+                            }
 
-                        if (!settings.GenericFile.ColumnLayout[c.ColumnIndex].Skip)
-                        {
-                            c.ColumnHeader = settings.GenericFile.ColumnLayout[c.ColumnIndex].InfluxName;
-                            columnHeaders.Add(c);
+                            if (!settings.GenericFile.ColumnLayout[c.ColumnIndex].Skip)
+                            {
+                                c.ColumnHeader = settings.GenericFile.ColumnLayout[c.ColumnIndex].InfluxName;
+                                columnHeaders.Add(c);
+                            }
                         }
                     }
                 }

--- a/Influxer/GenericFile.cs
+++ b/Influxer/GenericFile.cs
@@ -20,15 +20,15 @@ namespace AdysTech.Influxer
 
         public GenericFile()
         {
-            settings = InfluxerConfigSection.GetCurrentOrDefault ();
-            pattern = new Regex (settings.GenericFile.ColumnSplitter, RegexOptions.Compiled);
-            defaultTags = new Dictionary<string, string> ();
-            if ( settings.GenericFile.DefaultTags.Tags != null && settings.GenericFile.DefaultTags.Tags.Count > 0 )
+            settings = InfluxerConfigSection.GetCurrentOrDefault();
+            pattern = new Regex(settings.GenericFile.ColumnSplitter, RegexOptions.Compiled);
+            defaultTags = new Dictionary<string, string>();
+            if (settings.GenericFile.DefaultTags.Tags != null && settings.GenericFile.DefaultTags.Tags.Count > 0)
             {
-                foreach ( var tag in settings.GenericFile.DefaultTags.Tags )
+                foreach (var tag in settings.GenericFile.DefaultTags.Tags)
                 {
-                    var tags = tag.Split ('=');
-                    defaultTags.Add (tags[0], tags[1]);
+                    var tags = tag.Split('=');
+                    defaultTags.Add(tags[0], tags[1]);
                 }
             }
         }
@@ -41,139 +41,181 @@ namespace AdysTech.Influxer
 
             try
             {
-                Stopwatch stopwatch = new Stopwatch ();
-                stopwatch.Start ();
 
-                List<GenericColumn> columnHeaders;
+                if (settings.GenericFile.HeaderMissing && settings.GenericFile.ColumnLayout.Count == 0)
+                {
+                    Console.WriteLine("Header missing, but no columns defined in configuration. Cannot proceed!!");
+                    Console.Error.WriteLine("Header missing, but no columns defined in configuration. Cannot proceed!!");
+                    return ExitCode.InvalidArgument;
+                }
 
-                var firstLine = File.ReadLines (InputFileName).Skip (settings.GenericFile.HeaderRow - 1).FirstOrDefault ();
-                columnHeaders = ParseGenericColumns (firstLine);
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+
+
+                List<GenericColumn> columnHeaders = new List<GenericColumn>();
+
+                if (!settings.GenericFile.HeaderMissing)
+                {
+                    var firstLine = File.ReadLines(InputFileName).Skip(settings.GenericFile.HeaderRow - 1).FirstOrDefault();
+                    var columns = ParseGenericColumns(firstLine);
+                    foreach (var c in columns)
+                    {
+                        if (!String.IsNullOrWhiteSpace(settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile) && settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile != c.ColumnHeader)
+                        {
+                            Console.WriteLine("Column Mismatch: Column[%0] defined in configuration %1, found %2. Cannot proceed!!", c.ColumnIndex, settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile, c.ColumnHeader);
+                            Console.Error.WriteLine("Column Mismatch: Column[%0] defined in configuration %1, found %2. Cannot proceed!!", c.ColumnIndex, settings.GenericFile.ColumnLayout[c.ColumnIndex].NameInFile, c.ColumnHeader);
+                            return ExitCode.InvalidArgument;
+                        }
+
+                        if (!settings.GenericFile.ColumnLayout[c.ColumnIndex].Skip)
+                        {
+                            c.ColumnHeader = settings.GenericFile.ColumnLayout[c.ColumnIndex].InfluxName;
+                            columnHeaders.Add(c);
+                        }
+                    }
+                }
+                else
+                {
+                    var index = 0;
+                    foreach (ColumnConfig c in settings.GenericFile.ColumnLayout)
+                    {
+                        if (!c.Skip)
+                            columnHeaders.Add(new GenericColumn() { ColumnHeader = c.InfluxName, ColumnIndex = index, Type = c.DataType });
+                        index++;
+                    }
+                }
 
                 Dictionary<string, List<string>> dbStructure;
-                if ( settings.GenericFile.Filter != Filters.None )
+                if (settings.GenericFile.Filter != Filters.None)
                 {
-                    var filterColumns = ParseGenericColumns (settings.GenericFile.ColumnsFilter.Columns.ToString ());
+                    if (settings.GenericFile.Filter == Filters.Columns && settings.GenericFile.ColumnLayout != null && settings.GenericFile.ColumnLayout.Count > 0)
+                        Console.WriteLine("Column Filtering is not applicable when columns are defined in Config file. Use the Skip attribute on each column to filter them");
 
-                    dbStructure = await client.GetInfluxDBStructureAsync (settings.InfluxDB.DatabaseName);
-                    columnHeaders = FilterGenericColumns (columnHeaders, filterColumns, dbStructure);
+                    var filterColumns = ParseGenericColumns(settings.GenericFile.ColumnsFilter.Columns.ToString());
+
+                    dbStructure = await client.GetInfluxDBStructureAsync(settings.InfluxDB.DatabaseName);
+                    columnHeaders = FilterGenericColumns(columnHeaders, filterColumns, dbStructure);
 
                 }
 
-                var validity = ValidateData (InputFileName, columnHeaders);
+                var validity = ValidateData(InputFileName, columnHeaders);
 
-                var failureReasons = new Dictionary<Type, FailureTracker> ();
+                var failureReasons = new Dictionary<Type, FailureTracker>();
 
-                List<IInfluxDatapoint> points = new List<IInfluxDatapoint> (), retryQueue = new List<IInfluxDatapoint> ();
+                List<IInfluxDatapoint> points = new List<IInfluxDatapoint>(), retryQueue = new List<IInfluxDatapoint>();
 
-                //Parallel.ForEach (File.ReadLines (inputFileName).Skip (1), (string line) =>
-                foreach ( var line in File.ReadLines (InputFileName).Skip (settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows) )
+                foreach (var line in File.ReadLines(InputFileName).Skip(settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows))
                 {
+                    if (String.IsNullOrWhiteSpace(line) || (!String.IsNullOrEmpty(settings.GenericFile.CommentMarker) && line.StartsWith(settings.GenericFile.CommentMarker)))
+                        continue;
+
                     try
                     {
-                        var point = ProcessGenericLine (line, columnHeaders);
-                        if ( point == null )
+                        var point = ProcessGenericLine(line, columnHeaders);
+                        if (point == null)
                             failedLines++;
                         else
-                            points.Add (point);
+                            points.Add(point);
 
-                        if ( points.Count >= settings.InfluxDB.PointsInSingleBatch )
+                        if (points.Count >= settings.InfluxDB.PointsInSingleBatch)
                         {
                             bool result = false;
                             try
                             {
-                                result = await client.PostPointsAsync (settings.InfluxDB.DatabaseName, points);
+                                result = await client.PostPointsAsync(settings.InfluxDB.DatabaseName, points);
                             }
-                            catch ( ServiceUnavailableException )
+                            catch (ServiceUnavailableException)
                             {
                                 result = false;
                             }
 
-                            if ( result )
+                            if (result)
                             {
                                 failedReqCount = 0;
                             }
                             else
                             {
                                 //add failed to retry queue
-                                retryQueue.AddRange (points.Where (p => p.Saved != true));
+                                retryQueue.AddRange(points.Where(p => p.Saved != true));
 
                                 //avoid failing on too many points
-                                if ( ++failedReqCount > 3 )
+                                if (++failedReqCount > 3)
                                     break;
                             }
                             //a point will be either posted to Influx or in retry queue
-                            points.Clear ();
+                            points.Clear();
                         }
                     }
-                    catch ( Exception e )
+                    catch (Exception e)
                     {
                         failedLines++;
-                        var type = e.GetType ();
-                        if ( !failureReasons.ContainsKey (type) )
-                            failureReasons.Add (type, new FailureTracker () { ExceptionType = type, Message = e.Message });
-                        failureReasons[type].LineNumbers.Add (linesProcessed + settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows + 1);
+                        var type = e.GetType();
+                        if (!failureReasons.ContainsKey(type))
+                            failureReasons.Add(type, new FailureTracker() { ExceptionType = type, Message = e.Message });
+                        failureReasons[type].LineNumbers.Add(linesProcessed + settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows + 1);
                     }
 
                     linesProcessed++;
 
-                    if ( failedLines > 0 || retryQueue.Count > 0 )
-                        Console.Write ("\r{0} Processed {1}, Failed {2}, Queued {3}                        ", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), linesProcessed, failedLines, retryQueue.Count);
+                    if (failedLines > 0 || retryQueue.Count > 0)
+                        Console.Write("\r{0} Processed {1}, Failed {2}, Queued {3}                        ", stopwatch.Elapsed.ToString(@"hh\:mm\:ss"), linesProcessed, failedLines, retryQueue.Count);
                     else
-                        Console.Write ("\r{0} Processed {1}                          ", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), linesProcessed);
+                        Console.Write("\r{0} Processed {1}                          ", stopwatch.Elapsed.ToString(@"hh\:mm\:ss"), linesProcessed);
 
                 }
 
                 //if we reached here due to repeated failures
-                if ( retryQueue.Count >= settings.InfluxDB.PointsInSingleBatch * 3 || failedReqCount > 3 )
-                    throw new InvalidOperationException ("InfluxDB is not able to accept points!! Please check InfluxDB logs for error details!");
+                if (retryQueue.Count >= settings.InfluxDB.PointsInSingleBatch * 3 || failedReqCount > 3)
+                    throw new InvalidOperationException("InfluxDB is not able to accept points!! Please check InfluxDB logs for error details!");
 
 
                 //finally few points may be left out which were not processed (say 10 points left, but we check for 100 points in a batch)
-                if ( points != null && points.Count > 0 )
+                if (points != null && points.Count > 0)
                 {
 
-                    if ( await client.PostPointsAsync (settings.InfluxDB.DatabaseName, points) )
-                        points.Clear ();
+                    if (await client.PostPointsAsync(settings.InfluxDB.DatabaseName, points))
+                        points.Clear();
                     else
                     {
                         failedReqCount++;
                         //add failed to retry queue
-                        retryQueue.AddRange (points.Where (p => p.Saved != true));
+                        retryQueue.AddRange(points.Where(p => p.Saved != true));
                     }
                 }
 
                 //retry all previously failed points
-                if ( retryQueue.Count > 0 )
+                if (retryQueue.Count > 0)
                 {
-                    Console.WriteLine ("\n {0} Retrying {1} failed points", stopwatch.Elapsed.ToString (@"hh\:mm\:ss"), retryQueue.Count);
-                    if ( await client.PostPointsAsync (settings.InfluxDB.DatabaseName, retryQueue) )
-                        retryQueue.Clear ();
+                    Console.WriteLine("\n {0} Retrying {1} failed points", stopwatch.Elapsed.ToString(@"hh\:mm\:ss"), retryQueue.Count);
+                    if (await client.PostPointsAsync(settings.InfluxDB.DatabaseName, retryQueue))
+                        retryQueue.Clear();
                     else
                     {
                         failedLines += retryQueue.Count;
-                        if ( retryQueue.Count >= settings.InfluxDB.PointsInSingleBatch * 3 || ++failedReqCount > 4 )
-                            throw new InvalidOperationException ("InfluxDB is not able to accept points!! Please check InfluxDB logs for error details!");
+                        if (retryQueue.Count >= settings.InfluxDB.PointsInSingleBatch * 3 || ++failedReqCount > 4)
+                            throw new InvalidOperationException("InfluxDB is not able to accept points!! Please check InfluxDB logs for error details!");
                     }
                 }
 
-                stopwatch.Stop ();
-                if ( failedLines > 0 )
+                stopwatch.Stop();
+                if (failedLines > 0)
                 {
-                    Console.WriteLine ("\n Done!! Processed {0}, failed to insert {1}", linesProcessed, failedLines);
-                    Console.Error.WriteLine ("Process Started {0}, Input {1}, Processed{2}, Failed:{3}", ( DateTime.Now - stopwatch.Elapsed ), InputFileName, linesProcessed, failedLines);
-                    foreach ( var f in failureReasons.Values )
-                        Console.Error.WriteLine ("{0} lines ({1}) failed due to {2} ({3})", f.Count, String.Join (",", f.LineNumbers), f.ExceptionType, f.Message);
-                    if ( failedLines == linesProcessed )
+                    Console.WriteLine("\n Done!! Processed {0}, failed to insert {1}", linesProcessed, failedLines);
+                    Console.Error.WriteLine("Process Started {0}, Input {1}, Processed{2}, Failed:{3}", (DateTime.Now - stopwatch.Elapsed), InputFileName, linesProcessed, failedLines);
+                    foreach (var f in failureReasons.Values)
+                        Console.Error.WriteLine("{0} lines ({1}) failed due to {2} ({3})", f.Count, String.Join(",", f.LineNumbers), f.ExceptionType, f.Message);
+                    if (failedLines == linesProcessed)
                         return ExitCode.UnableToProcess;
                     else
                         return ExitCode.ProcessedWithErrors;
                 }
 
             }
-            catch ( Exception e )
+            catch (Exception e)
             {
-                Console.Error.WriteLine ("Failed to process {0}", InputFileName);
-                Console.Error.WriteLine ("\r\nError!! {0}:{1} - {2}", e.GetType ().Name, e.Message, e.StackTrace);
+                Console.Error.WriteLine("Failed to process {0}", InputFileName);
+                Console.Error.WriteLine("\r\nError!! {0}:{1} - {2}", e.GetType().Name, e.Message, e.StackTrace);
                 return ExitCode.UnknownError;
             }
             return ExitCode.Success;
@@ -182,30 +224,42 @@ namespace AdysTech.Influxer
         private bool ValidateData(string InputFileName, List<GenericColumn> columnHeaders)
         {
             var lineNo = 0;
-            if ( settings.GenericFile.ValidateRows == 0 )
+            if (settings.GenericFile.ValidateRows == 0)
                 settings.GenericFile.ValidateRows = 1;
 
-            foreach ( var line in File.ReadLines (InputFileName).Skip (settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows) )
+            foreach (var line in File.ReadLines(InputFileName).Skip(settings.GenericFile.HeaderRow + settings.GenericFile.SkipRows))
             {
-                var columns = pattern.Split (line.Replace ("\"", ""));
+                if (String.IsNullOrWhiteSpace(line) || (!String.IsNullOrEmpty(settings.GenericFile.CommentMarker) && line.StartsWith(settings.GenericFile.CommentMarker)))
+                    continue;
+
+                var columns = pattern.Split(line.Replace("\"", ""));
                 double value = 0.0;
 
-                foreach ( var c in columnHeaders.Skip (1) )
+                foreach (var c in columnHeaders)
                 {
-                    if ( c.Type == GenericColumn.ColumnDataType.Unknown )
+                    if (c.ColumnIndex == settings.GenericFile.TimeColumn - 1)
                     {
-                        if ( Double.TryParse (columns[c.ColumnIndex], out value) )
-                            c.Type = GenericColumn.ColumnDataType.Field;
-                        else
-                            c.Type = GenericColumn.ColumnDataType.Tag;
+                        DateTime timeStamp;
+                        if (!DateTime.TryParseExact(columns[settings.GenericFile.TimeColumn - 1], settings.GenericFile.TimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timeStamp))
+                            throw new FormatException("Couldn't parse " + columns[0] + " using format " + settings.GenericFile.TimeFormat + ", check -timeformat argument");
                     }
                     else
                     {
-                        if ( ( Double.TryParse (columns[c.ColumnIndex], out value) && c.Type == GenericColumn.ColumnDataType.Tag ) || ( c.Type == GenericColumn.ColumnDataType.Field && double.IsNaN (value) ) )
-                            throw new InvalidDataException (c.ColumnHeader + " has inconsistent data");
+                        if (c.Type == ColumnDataType.Unknown)
+                        {
+                            if (Double.TryParse(columns[c.ColumnIndex], out value))
+                                c.Type = ColumnDataType.Field;
+                            else
+                                c.Type = ColumnDataType.Tag;
+                        }
+                        else
+                        {
+                            if ((Double.TryParse(columns[c.ColumnIndex], out value) && c.Type == ColumnDataType.Tag) || (c.Type == ColumnDataType.Field && double.IsNaN(value)))
+                                throw new InvalidDataException(c.ColumnHeader + " has inconsistent data");
+                        }
                     }
                 }
-                if ( ++lineNo == settings.GenericFile.ValidateRows )
+                if (++lineNo == settings.GenericFile.ValidateRows)
                     break;
             }
             return true;
@@ -213,21 +267,21 @@ namespace AdysTech.Influxer
 
         private List<GenericColumn> ParseGenericColumns(string headerLine)
         {
-            var columns = new List<GenericColumn> ();
-            columns.AddRange (pattern.Split (headerLine).Select ((s, i) => new GenericColumn () { ColumnIndex = i, ColumnHeader = s.Replace (settings.InfluxDB.InfluxReserved.ReservedCharecters.ToCharArray (), settings.InfluxDB.InfluxReserved.ReplaceReservedWith) }));
+            var columns = new List<GenericColumn>();
+            columns.AddRange(pattern.Split(headerLine).Select((s, i) => new GenericColumn() { ColumnIndex = i, ColumnHeader = s.Replace(settings.InfluxDB.InfluxReserved.ReservedCharecters.ToCharArray(), settings.InfluxDB.InfluxReserved.ReplaceReservedWith) }));
             return columns;
         }
 
         private List<GenericColumn> FilterGenericColumns(List<GenericColumn> columns, List<GenericColumn> filterColumns, Dictionary<string, List<string>> dbStructure)
         {
-            switch ( settings.GenericFile.Filter )
+            switch (settings.GenericFile.Filter)
             {
                 case Filters.Measurement:
-                    return columns.Where (p => dbStructure.ContainsKey (settings.GenericFile.TableName)).ToList ();
+                    return columns.Where(p => dbStructure.ContainsKey(settings.GenericFile.TableName)).ToList();
                 case Filters.Field:
-                    return columns.Where (p => dbStructure.ContainsKey (settings.GenericFile.TableName) && dbStructure[settings.GenericFile.TableName].Contains (p.ColumnHeader)).ToList ();
+                    return columns.Where(p => dbStructure.ContainsKey(settings.GenericFile.TableName) && dbStructure[settings.GenericFile.TableName].Contains(p.ColumnHeader)).ToList();
                 case Filters.Columns:
-                    return columns.Where (p => filterColumns.Any (f => f.ColumnHeader == p.ColumnHeader)).ToList ();
+                    return columns.Where(p => filterColumns.Any(f => f.ColumnHeader == p.ColumnHeader)).ToList();
             }
             return columns;
         }
@@ -235,36 +289,38 @@ namespace AdysTech.Influxer
         private InfluxDatapoint<double> ProcessGenericLine(string line, List<GenericColumn> columnHeaders)
         {
 
-            var columns = pattern.Split (line.Replace ("\"", ""));
-            var columnCount = columns.Count ();
+            var columns = pattern.Split(line.Replace("\"", ""));
+            var columnCount = columns.Count();
 
-            InfluxDatapoint<double> point = new InfluxDatapoint<double> ();
+            InfluxDatapoint<double> point = new InfluxDatapoint<double>();
             point.Precision = settings.GenericFile.Precision;
             point.MeasurementName = settings.GenericFile.TableName;
 
             DateTime timeStamp;
-            if ( !DateTime.TryParseExact (columns[0], settings.GenericFile.TimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timeStamp) )
-                throw new FormatException ("Couldn't parse " + columns[0] + " using format " + settings.GenericFile.TimeFormat + ", check -timeformat argument");
-            point.UtcTimestamp = timeStamp.AddMinutes (settings.GenericFile.UtcOffset);
+            if (!DateTime.TryParseExact(columns[settings.GenericFile.TimeColumn - 1], settings.GenericFile.TimeFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out timeStamp))
+                throw new FormatException("Couldn't parse " + columns[0] + " using format " + settings.GenericFile.TimeFormat + ", check -timeformat argument");
+            point.UtcTimestamp = timeStamp.AddMinutes(settings.GenericFile.UtcOffset);
 
-            point.InitializeTags (defaultTags);
+            point.InitializeTags(defaultTags);
 
-            foreach ( var c in columnHeaders.Skip (1) )
+            foreach (var c in columnHeaders)
             {
+                if (c.ColumnIndex == settings.GenericFile.TimeColumn - 1) continue;
+
                 double value = double.NaN;
-                if ( c.Type == GenericColumn.ColumnDataType.Field )
+                if (c.Type == ColumnDataType.Field)
                 {
-                    if ( !Double.TryParse (columns[c.ColumnIndex], out value) )
-                        throw new InvalidDataException (c.ColumnHeader + " has inconsistent data, Unable to parse " + columns[c.ColumnIndex] + " as number");
-                    point.Fields.Add (c.ColumnHeader, Math.Round (value, 2));
+                    if (!Double.TryParse(columns[c.ColumnIndex], out value))
+                        throw new InvalidDataException(c.ColumnHeader + " has inconsistent data, Unable to parse \"" + columns[c.ColumnIndex] + "\" as number");
+                    point.Fields.Add(c.ColumnHeader, Math.Round(value, 2));
                 }
-                else if ( c.Type == GenericColumn.ColumnDataType.Tag )
-                    point.Tags.Add (c.ColumnHeader, columns[c.ColumnIndex].Replace (settings.InfluxDB.InfluxReserved.ReservedCharecters.ToCharArray (), settings.InfluxDB.InfluxReserved.ReplaceReservedWith));
+                else if (c.Type == ColumnDataType.Tag)
+                    point.Tags.Add(c.ColumnHeader, columns[c.ColumnIndex].Replace(settings.InfluxDB.InfluxReserved.ReservedCharecters.ToCharArray(), settings.InfluxDB.InfluxReserved.ReplaceReservedWith));
             }
 
 
-            if ( point.Fields.Count == 0 )
-                throw new InvalidDataException ("No values found on the row to post to Influx");
+            if (point.Fields.Count == 0)
+                throw new InvalidDataException("No values found on the row to post to Influx");
             return point;
         }
     }

--- a/Influxer/Influxer.csproj
+++ b/Influxer/Influxer.csproj
@@ -63,6 +63,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config\ColumnConfig.cs" />
+    <Compile Include="Config\ColumnLayoutConfig.cs" />
     <Compile Include="Config\CommandLineArgAttribute.cs" />
     <Compile Include="Config\GenericFileConfig.cs" />
     <Compile Include="Config\InfluxDBConfig.cs" />

--- a/Influxer/Program.cs
+++ b/Influxer/Program.cs
@@ -115,25 +115,29 @@ namespace AdysTech.Influxer
             }
             #endregion
 
-            try
+            if (totalArguments > 1)
             {
-                if ( !settings.ProcessCommandLineArguments (cmdArgs) )
+                try
                 {
-                    Console.Error.WriteLine ("Invalid commandline arguments!! Use /help to see valid ones");
-                    return (int) ExitCode.InvalidArgument;
+                    if (!settings.ProcessCommandLineArguments(cmdArgs))
+                    {
+                        Console.Error.WriteLine("Invalid commandline arguments!! Use /help to see valid ones");
+                        return (int)ExitCode.InvalidArgument;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.Error.WriteLine("Error processing arguments", e.GetType().Name, e.Message);
+                    return (int)ExitCode.InvalidArgument;
                 }
             }
-            catch ( Exception e )
+
+            if (cmdArgs.ContainsKey("/export"))
             {
-                Console.Error.WriteLine ("Error processing arguments", e.GetType ().Name, e.Message);
-                return (int) ExitCode.InvalidArgument;
+                InfluxerConfigSection.Export(Console.OpenStandardOutput(), totalArguments > 1 ? false : true);
+                return (int)ExitCode.Success;
             }
 
-            if ( cmdArgs.ContainsKey ("/export") )
-            {
-                InfluxerConfigSection.Export (Console.OpenStandardOutput (), totalArguments > 1 ? false : true);
-                return (int) ExitCode.Success;
-            }
 
             if ( cmdArgs.Count > 0 )
             {

--- a/Influxer/Properties/AssemblyInfo.cs
+++ b/Influxer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion ("0.3.3.0")]
-[assembly: AssemblyFileVersion ("0.3.3.0")]
+[assembly: AssemblyVersion ("0.3.5.0")]
+[assembly: AssemblyFileVersion ("0.3.5.0")]

--- a/Influxer/Properties/AssemblyInfo.cs
+++ b/Influxer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion ("0.3.5.0")]
-[assembly: AssemblyFileVersion ("0.3.5.0")]
+[assembly: AssemblyVersion ("0.4.0.0")]
+[assembly: AssemblyFileVersion ("0.4.0.0")]


### PR DESCRIPTION
Came across a custom report from a tool, which we wanted to pull into Influx. The file in question did not have any headers (after skipping all rows starting with #). With this version a file format (aka column layout) can be defined in the configuration, and Influxer will use that format instead of trying to figure out what column is a Tag and what is an Field column.
