### PR TITLE
Update App Veyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,7 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+/.vs/slnx.sqlite
+/.vs/ProjectSettings.json
+/.vs/ProjectSettings.json
+/.vs

--- a/Influxer/Influxer.csproj
+++ b/Influxer/Influxer.csproj
@@ -49,9 +49,8 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="AdysTech.InfluxDB.Client.Net, Version=0.5.9.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AdysTech.InfluxDB.Client.Net.0.5.9.1\lib\net451\AdysTech.InfluxDB.Client.Net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AdysTech.InfluxDB.Client.Net, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdysTech.InfluxDB.Client.Net.0.6.0\lib\net451\AdysTech.InfluxDB.Client.Net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Influxer/packages.config
+++ b/Influxer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AdysTech.InfluxDB.Client.Net" version="0.5.9.1" targetFramework="net451" />
+  <package id="AdysTech.InfluxDB.Client.Net" version="0.6.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,19 @@
 version: 0.{build}
+image: Visual Studio 2017
 pull_requests:
   do_not_increment_build_number: true
 branches:
   only:
   - master
 before_build:
-- cmd: nuget restore -verbosity detailed
-- set PATH="C:\Program Files (x86)\MSBuild\14.0\Bin";%PATH%
+- nuget restore
+- dotnet restore
+platform: Any CPU
+configuration: Release
 build:
   verbosity: minimal
 artifacts:
-- path: Influxer\bin\debug
-  name: InfluxerDebug
+- path: Influxer\bin\Release
+  name: InfluxerRelease
 before_test:
 - ps: Influxer.Test\TestSetup.ps1


### PR DESCRIPTION
To use Visual Studio 2017, to generate AnyCPU build.